### PR TITLE
feat(vite-plugin-shopify-modules): add possibility to handle sub/nested modules for organisation f…

### DIFF
--- a/packages/vite-plugin-shopify-modules/src/index.ts
+++ b/packages/vite-plugin-shopify-modules/src/index.ts
@@ -81,7 +81,7 @@ const linkModules = ({ modulesDir, themeRoot }: ResolvedVitePluginShopifyModules
         async (modules: string[]) => await Promise.all(modules.flatMap((module) => {
           const currentPath = path.resolve(modulesDir, module)
           // nested modules : if current path is a directory and has sub dir, re-run link modules script
-          if (lstatSync(currentPath).isDirectory()) {
+          if (existsSync(currentPath) && lstatSync(currentPath).isDirectory()) {
             const items = readdirSync(currentPath, { withFileTypes: true })
             const hasSubDir = items.find(dirent => dirent.isDirectory())
             if (hasSubDir != null) {


### PR DESCRIPTION
Hi,

Tanks you for your work, theses plugins are very helpful ! 
However, if we move every sections and snippets into modules it become a mess very quickly. 
So I added the possibility to have sub nested modules, with that we can have a better files organisation into modules.
```
│── modules
  |   └─ main-pages
  │       └─ main-product
  │           └─ main-product.js
  │           └─ main-product.css
  │           └─ main-product.section.liquid # Symlink to /sections/main-product.liquid
  │       └─ main-collection
  │           └─ main-collection.js
  │           └─ main-collection.css
  │           └─ main-collection.section.liquid # Symlink to /sections/main-collection.liquid
  |   └─ cart
  │       └─ cart-drawer
  │            └─ cart-drawer.js
  │            └─ cart-drawer.css
  │            └─ cart-drawer.section.liquid # Symlink to /sections/cart-drawer.liquid
  │            └─ cart-drawer.snippet.liquid # Symlink to /snippets/cart-drawer.liquid
  │       └─ cart-item
  │            └─ cart-item.js
  │            └─ cart-item.css
  │            └─ cart-item.section.liquid # Symlink to /sections/cart-item.liquid
  │            └─ cart-item.snippet.liquid # Symlink to /snippets/cart-item.liquid
```

I tried to keep the code simple.
What do you think about this improvement ?

Regards