### PR TITLE
vite-plugin-shopify: Add snippetFile option

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -43,3 +43,10 @@ Front-end entry points directory.
 - **Default:** `[]`
 
 Additional files to use as entry points (accepts an array of file paths or glob patterns).
+
+## snippetFile
+
+- **Type:** `LiquidFile`
+- **Default:** `vite-tag.liquid`
+
+Specifies the file name of the snippet that loads your assets.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -46,7 +46,7 @@ Additional files to use as entry points (accepts an array of file paths or glob 
 
 ## snippetFile
 
-- **Type:** `LiquidFile`
+- **Type:** `string`
 - **Default:** `vite-tag.liquid`
 
 Specifies the file name of the snippet that loads your assets.

--- a/packages/vite-plugin-shopify/README.md
+++ b/packages/vite-plugin-shopify/README.md
@@ -42,6 +42,8 @@ export default {
       entrypointsDir: 'frontend/entrypoints',
       // Additional files to use as entry points (accepts an array of file paths or glob patterns)
       additionalEntrypoints: []
+      // Specifies the file name of the snippet that loads your assets
+      snippetFile: 'vite-tag.liquid'
     })
   ]
 }

--- a/packages/vite-plugin-shopify/src/html.ts
+++ b/packages/vite-plugin-shopify/src/html.ts
@@ -15,7 +15,7 @@ export default function shopifyHTML (options: Required<VitePluginShopifyOptions>
   let viteDevServerUrl: DevServerUrl
   let modulesPath = ''
 
-  const viteTagSnippetPath = path.resolve(options.themeRoot, 'snippets/vite-tag.liquid')
+  const viteTagSnippetPath = path.resolve(options.themeRoot, `snippets/${options.snippetFile}`)
 
   return {
     name: 'vite-plugin-shopify-html',

--- a/packages/vite-plugin-shopify/src/options.ts
+++ b/packages/vite-plugin-shopify/src/options.ts
@@ -9,11 +9,13 @@ export const resolveOptions = (
   const sourceCodeDir = options.sourceCodeDir ?? 'frontend'
   const entrypointsDir = options.entrypointsDir ?? normalizePath(path.join(sourceCodeDir, 'entrypoints'))
   const additionalEntrypoints = options.additionalEntrypoints ?? []
+  const snippetFile = options.snippetFile ?? 'vite-tag.liquid'
 
   return {
     themeRoot,
     sourceCodeDir,
     entrypointsDir,
-    additionalEntrypoints
+    additionalEntrypoints,
+    snippetFile
   }
 }

--- a/packages/vite-plugin-shopify/src/types.ts
+++ b/packages/vite-plugin-shopify/src/types.ts
@@ -3,6 +3,9 @@ export interface VitePluginShopifyOptions {
   entrypointsDir?: string
   additionalEntrypoints?: string[]
   sourceCodeDir?: string
+  snippetFile?: LiquidFile
 }
 
 export type DevServerUrl = `${'http' | 'https'}://${string}:${number}`
+
+export type LiquidFile = `${string}.liquid`

--- a/packages/vite-plugin-shopify/src/types.ts
+++ b/packages/vite-plugin-shopify/src/types.ts
@@ -3,9 +3,7 @@ export interface VitePluginShopifyOptions {
   entrypointsDir?: string
   additionalEntrypoints?: string[]
   sourceCodeDir?: string
-  snippetFile?: LiquidFile
+  snippetFile?: string
 }
 
 export type DevServerUrl = `${'http' | 'https'}://${string}:${number}`
-
-export type LiquidFile = `${string}.liquid`

--- a/packages/vite-plugin-shopify/test/config.test.ts
+++ b/packages/vite-plugin-shopify/test/config.test.ts
@@ -57,6 +57,7 @@ describe('resolveOptions', () => {
     expect(options.sourceCodeDir).toBe('frontend')
     expect(options.entrypointsDir).toBe('frontend/entrypoints')
     expect(options.additionalEntrypoints).toEqual([])
+    expect(options.snippetFile).toEqual('vite-tag.liquid')
   })
 
   it('accepts a partial configuration', () => {

--- a/themes/vite-shopify-example/vite.config.ts
+++ b/themes/vite-shopify-example/vite.config.ts
@@ -12,13 +12,14 @@ export default defineConfig({
   publicDir: 'public',
   resolve: {
     alias: {
-      '~~': '/frontend',
-      '@@': '/frontend'
+      '~~': 'frontend',
+      '@@': 'frontend'
     }
   },
   plugins: [
     basicSsl(),
     shopify({
+      snippetFile: 'vite-tag.liquid',
       additionalEntrypoints: [
         'frontend/foo.ts', // relative to sourceCodeDir
         'resources/bar.ts', // relative to themeRoot


### PR DESCRIPTION
This PR adds the `snippetFile` option to allow developers to specify the file name of the snippet that loads their assets in a Shopify theme.