### PR TITLE
Add example for use in theme app extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,17 @@ Modern frontend tooling for Shopify theme development using Vite for a best-in-c
 
 ## Examples
 
-| Theme                                                               |
-| ------------------------------------------------------------------- |
-| [hydrogen-theme](https://github.com/montalvomiguelo/hydrogen-theme) |
-| [preact-shopify](./examples/preact-shopify)                           |
-| [vite-shopify-example](./examples/vite-shopify-example)               |
+| Theme App Extension
+| --------------------------------------------------------------------------------------- |
+| [Shopify Vite Extension](https://github.com/montalvomiguelo/theme-app-extension-vite)   |
+
+---
+
+| Theme                                                                |
+| -------------------------------------------------------------------- |
+| [Hydrogen Theme](https://github.com/montalvomiguelo/hydrogen-theme)  |
+| [Preact Shopify](./examples/preact-shopify)                          |
+| [Basic Example](./examples/vite-shopify-example)                     |
 
 ## Contribution
 

--- a/docs/guide/example-projects.md
+++ b/docs/guide/example-projects.md
@@ -2,6 +2,12 @@
 
 Explore examples of core features and common use cases.
 
+## Theme App Extensions
+
+- [Shopify Vite Extension](https://github.com/montalvomiguelo/theme-app-extension-vite)
+
+## Themes
+
 - [Hydrogen Theme][hydrogen-theme]
 - [Basic Example][basic-example]
 - [Preact Shopify][preact-shopify]

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ features:
     details: Your theme's JavaScript and CSS files are treated as entrypoints for Vite.
   - icon: 🏷
     title: Smart tag generation
-    details: Smart tags will be generated to load the scripts and styles of your theme.
+    details: Smart tags generate to load the scripts and styles of your theme.
   - icon: 🌎
     title: Shopify CDN Support
     details: Full support for assets served from Shopify's CDN.


### PR DESCRIPTION
Followup to #57 

* We can also use the Shopify Vite Plugin for building Theme App Extensions.

* In this PR we add 1 [example](https://github.com/montalvomiguelo/theme-app-extension-vite) to our docs.

https://user-images.githubusercontent.com/5134470/224541432-30d07d5a-d64a-4c32-9ee3-5ea58e860f9d.mp4

cc @tommypepsi 

