### PR TITLE
Rename Options interface

### DIFF
--- a/packages/vite-plugin-shopify/src/config.ts
+++ b/packages/vite-plugin-shopify/src/config.ts
@@ -3,12 +3,12 @@ import { Plugin, UserConfig, normalizePath } from 'vite'
 import glob from 'fast-glob'
 import createDebugger from 'debug'
 
-import type { VitePluginShopifyOptions } from './types'
+import type { Options } from './types'
 
 const debug = createDebugger('vite-plugin-shopify:config')
 
 // Plugin for setting necessary Vite config to support Shopify plugin functionality
-export default function shopifyConfig (options: Required<VitePluginShopifyOptions>): Plugin {
+export default function shopifyConfig (options: Required<Options>): Plugin {
   return {
     name: 'vite-plugin-shopify-config',
     config (config: UserConfig): UserConfig {

--- a/packages/vite-plugin-shopify/src/html.ts
+++ b/packages/vite-plugin-shopify/src/html.ts
@@ -5,12 +5,12 @@ import { Manifest, Plugin, ResolvedConfig, normalizePath } from 'vite'
 import createDebugger from 'debug'
 
 import { CSS_EXTENSIONS_REGEX, KNOWN_CSS_EXTENSIONS } from './constants'
-import type { VitePluginShopifyOptions, DevServerUrl } from './types'
+import type { Options, DevServerUrl } from './types'
 
 const debug = createDebugger('vite-plugin-shopify:html')
 
 // Plugin for generating vite-tag liquid theme snippet with entry points for JS and CSS assets
-export default function shopifyHTML (options: Required<VitePluginShopifyOptions>): Plugin {
+export default function shopifyHTML (options: Required<Options>): Plugin {
   let config: ResolvedConfig
   let viteDevServerUrl: DevServerUrl
 

--- a/packages/vite-plugin-shopify/src/index.ts
+++ b/packages/vite-plugin-shopify/src/index.ts
@@ -1,11 +1,11 @@
 import { Plugin } from 'vite'
 
 import { resolveOptions } from './options'
-import type { VitePluginShopifyOptions } from './types'
+import type { Options } from './types'
 import shopifyConfig from './config'
 import shopifyHtml from './html'
 
-const vitePluginShopify = (options: VitePluginShopifyOptions = {}): Plugin[] => {
+const vitePluginShopify = (options: Options = {}): Plugin[] => {
   const resolvedOptions = resolveOptions(options)
 
   const plugins = [

--- a/packages/vite-plugin-shopify/src/options.ts
+++ b/packages/vite-plugin-shopify/src/options.ts
@@ -1,10 +1,10 @@
 import path from 'node:path'
 import { normalizePath } from 'vite'
-import type { VitePluginShopifyOptions } from './types'
+import type { Options } from './types'
 
 export const resolveOptions = (
-  options: VitePluginShopifyOptions
-): Required<VitePluginShopifyOptions> => {
+  options: Options
+): Required<Options> => {
   const themeRoot = options.themeRoot ?? './'
   const sourceCodeDir = options.sourceCodeDir ?? 'frontend'
   const entrypointsDir = options.entrypointsDir ?? normalizePath(path.join(sourceCodeDir, 'entrypoints'))

--- a/packages/vite-plugin-shopify/src/types.ts
+++ b/packages/vite-plugin-shopify/src/types.ts
@@ -1,4 +1,4 @@
-export interface VitePluginShopifyOptions {
+export interface Options {
   /**
    * Root path to your Shopify theme directory.
    *


### PR DESCRIPTION
Rename the Options interface, so it's easier to read.

<img width="623" alt="Screen Shot 2023-03-20 at 7 11 05 PM" src="https://user-images.githubusercontent.com/5134470/226503327-415765ad-e208-4867-bc8f-0ff0e0c3419f.png">
