### PR TITLE
Fix esm support

### DIFF
--- a/examples/vite-shopify-example/package.json
+++ b/examples/vite-shopify-example/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vite-shopify-example",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "cross-env DEBUG=vite-plugin-shopify:* vite",
     "build": "cross-env DEBUG=vite-plugin-shopify:* vite build",

--- a/examples/vite-shopify-example/tsconfig.json
+++ b/examples/vite-shopify-example/tsconfig.json
@@ -9,6 +9,7 @@
     "node_modules"
   ],
   "compilerOptions": {
+    "lib": ["esnext", "dom"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["frontend/*"],

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Default",
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2020",
     "module": "esnext",
     "lib": ["esnext"],
     "moduleResolution": "node",

--- a/packages/vite-plugin-shopify/src/html.ts
+++ b/packages/vite-plugin-shopify/src/html.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { AddressInfo } from 'node:net'
+import { fileURLToPath } from 'node:url'
 import { Manifest, Plugin, ResolvedConfig, normalizePath } from 'vite'
 import createDebugger from 'debug'
 
@@ -8,6 +9,11 @@ import { CSS_EXTENSIONS_REGEX, KNOWN_CSS_EXTENSIONS } from './constants'
 import type { Options, DevServerUrl } from './types'
 
 const debug = createDebugger('vite-plugin-shopify:html')
+
+// __dirname polyfill for ESM
+const _dirname = typeof __dirname !== 'undefined'
+  ? __dirname
+  : path.dirname(fileURLToPath(import.meta.url))
 
 // Plugin for generating vite-tag liquid theme snippet with entry points for JS and CSS assets
 export default function shopifyHTML (options: Required<Options>): Plugin {
@@ -55,7 +61,7 @@ export default function shopifyHTML (options: Required<Options>): Plugin {
           res.statusCode = 404
 
           res.end(
-            fs.readFileSync(path.join(__dirname, 'dev-server-index.html')).toString()
+            fs.readFileSync(path.join(_dirname, 'dev-server-index.html')).toString()
           )
         }
 


### PR DESCRIPTION
**Issue**

`__dirname` is unavailable when enabling ESM via `package.json`, which makes the plugin throw the following error:

```
[vite] Internal server error: __dirname is not defined
```

**Solution**

This PR introduces a polyfill for `__dirname` leveraging `import.meta.url` to support ESM.





