### PR TITLE
enable simple code split via file name on production builds

### DIFF
--- a/packages/vite-plugin-shopify/src/html.ts
+++ b/packages/vite-plugin-shopify/src/html.ts
@@ -175,8 +175,16 @@ const scriptTag = (fileName: string): string =>
   `<script src="{{ '${fileName}' | asset_url | split: '?' | first }}" type="module" crossorigin="anonymous"></script>`
 
 // Generate a production stylesheet link tag for a style asset
-const stylesheetTag = (fileName: string): string =>
-  `{{ '${fileName}' | asset_url | split: '?' | first | stylesheet_tag: preload: preload_stylesheet }}`
+const stylesheetTag = (fileName: string): string => {
+  if (!fileName.includes('.s-up') && !fileName.includes('.m-up')) {
+    return `{{ '${fileName}' | asset_url | split: '?' | first | stylesheet_tag: preload: preload_stylesheet }}`
+  } else if (fileName.includes('.s-up')) {
+    return `{{ '${fileName}' | asset_url | split: '?' | first | stylesheet_tag: media: '(min-width: 750px)' }}`
+  } else if (fileName.includes('.m-up')) {
+    return `{{ '${fileName}' | asset_url | split: '?' | first | stylesheet_tag: media: '(min-width: 990px)' }}`
+  }
+  throw new Error(`Unexpected stylesheet file name: ${fileName}`)
+}
 
 // Generate vite-tag snippet for development
 const viteTagSnippetDev = (assetHost: string, entrypointsDir: string, reactPlugin: Plugin | undefined): string =>


### PR DESCRIPTION
needed this bc I'm working on a typescript/dawn template and trying to beat my mobile FCP high score

it's not documented but the stylesheet_tag in liquid allows you to pass any parameter that would normally be rendered in a stylesheet so I'm using that to add media queries

passes all tests & doesn't change default behavior. if you think this would be a useful feature I can add some more control here, this is just a rough patch to fit my use case