### PR TITLE
WIP: Cleanup plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Modern frontend tooling for Shopify theme development using Vite for a best-in-c
 | ------------------------------------------------------------- | ------------------------------------------------------------ |
 | [vite-plugin-shopify](./packages/vite-plugin-shopify)         | [Changelog](./packages/vite-plugin-shopify/CHANGELOG.md)     |
 | [vite-plugin-page-reload](./packages/vite-plugin-page-reload) | [Changelog](./packages/vite-plugin-page-reload/CHANGELOG.md) |
+| [vite-plugin-cleanup](./packages/vite-plugin-cleanup)         | [Changelog](./packages/vite-plugin-cleanup/CHANGELOG.md)     |
 
 ## Documentation
 

--- a/packages/vite-plugin-cleanup/.eslintignore
+++ b/packages/vite-plugin-cleanup/.eslintignore
@@ -1,0 +1,2 @@
+dist
+assets

--- a/packages/vite-plugin-cleanup/CHANGELOG.md
+++ b/packages/vite-plugin-cleanup/CHANGELOG.md
@@ -1,0 +1,7 @@
+# vite-plugin-cleanup
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial Release

--- a/packages/vite-plugin-cleanup/README.md
+++ b/packages/vite-plugin-cleanup/README.md
@@ -1,0 +1,30 @@
+# vite-plugin-cleanup
+
+Automatically cleanup built files in assets folder
+
+```js
+// vite.config.js
+import cleanup from 'vite-plugin-cleanup'
+
+export default {
+  plugins: [
+    cleanup()
+  ]
+}
+```
+
+## Configuration
+
+### cleanUpSourceMaps
+
+Type: `'auto' | boolean`
+
+Default: 'auto'
+
+Whether the source map files `*.js.map` should be cleaned up or not.
+
+## Acknowledgements
+
+This plugin is based on the ideas from the following project
+
+* [vite-plugin-shopify-clean](https://www.npmjs.com/package/@by-association-only/vite-plugin-shopify-clean)

--- a/packages/vite-plugin-cleanup/package.json
+++ b/packages/vite-plugin-cleanup/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "vite-plugin-cleanup",
+  "version": "0.1.0",
+  "description": "",
+  "repository": {
+    "url": "barrel/shopify-vite",
+    "directory": "packages/vite-plugin-cleanup"
+  },
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "type": "module",
+  "scripts": {
+    "dev": "npm run watch",
+    "build": "tsup src/index.ts --dts --format esm --clean",
+    "watch": "tsup src/index.ts --dts --format esm --watch",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "vite": "^4.0.4"
+  },
+  "dependencies": {
+    "fast-glob": "^3.2.11"
+  },
+  "devDependencies": {
+    "tsconfig": "workspace:*"
+  }
+}

--- a/packages/vite-plugin-cleanup/src/index.ts
+++ b/packages/vite-plugin-cleanup/src/index.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs'
+import fsPromises from 'node:fs/promises'
+import path from 'node:path'
+import { Plugin, UserConfig, Manifest, ResolvedConfig, normalizePath } from 'vite'
+import glob from 'fast-glob'
+
+const getFilesInManifest = (manifest: Manifest): string[] => {
+  if (!manifest) {
+    return []
+  }
+
+  const filesListedInImports = new Set(
+    Object.values(manifest).flatMap((block) => "imports" in block ? block.imports : [])
+  )
+
+  return Object.entries(manifest).flatMap(([key, block]) => {
+    let file = ''
+
+    if (key.startsWith('-') && filesListedInImports.has(key)) {
+      file = block.file
+    } else if (!key.startsWith('-')) {
+      file = block.file
+    }
+
+    if (file) {
+      const mapFile = `${file}.map`
+
+      if (fs.existsSync(mapFile)) {
+        return [file, mapFile]
+      }
+
+      return [file]
+    }
+
+    return []
+  })
+}
+
+const shouldCleanUpSourceMaps = (resolvedConfig: ResolvedConfig, config: Config): boolean => {
+  const { cleanUpSourceMaps = 'auto' } = config
+
+  return cleanUpSourceMaps === 'auto' ? resolvedConfig.build.sourcemap === true : cleanUpSourceMaps
+}
+
+const unlinkIgnoreError = async (filePath: string): Promise<void> => {
+  try {
+    await fsPromises.unlink(filePath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
+  }
+}
+
+const cleanUpFiles = async (outDir: string, manifest: Manifest, cleanUpSourceMaps: boolean): Promise<void> => {
+  const filesInManifest: string[] = getFilesInManifest(manifest)
+  const sourceMapFiles: string[] = cleanUpSourceMaps ? glob.sync(path.join(outDir, '*.js.map')) : []
+
+  const filesToCleanup = [
+    ...filesInManifest.map(file => path.join(outDir, file)),
+    ...sourceMapFiles
+  ].map(normalizePath)
+
+  await Promise.all(filesToCleanup.map(file => unlinkIgnoreError(file)))
+}
+
+export interface Config {
+  /**
+   * Whether the source map files should be cleaned up
+   * @default 'auto'
+   */
+  cleanUpSourceMaps?: 'auto' | boolean
+}
+
+const cleanup = (config: Config = {}): Plugin => {
+  let viteConfig: ResolvedConfig
+  let buildStartFirstRun = true
+
+  return {
+    name: 'vite-plugin-cleanup',
+    config(): UserConfig {
+      // Enable manifest generation
+      return {
+        build: {
+          manifest: true
+        }
+      }
+    },
+    configResolved(resolvedConfig: ResolvedConfig): void {
+      viteConfig = resolvedConfig
+    },
+    buildStart: async () => {
+      if (!viteConfig || process.env.NODE_ENV === 'development' || !process.env.VITE_WATCH || !buildStartFirstRun) {
+        return
+      }
+
+      buildStartFirstRun = false
+      const outDir = viteConfig.build.outDir
+      const manifestFile = normalizePath(path.join(outDir, 'manifest.json'))
+
+      if (!fs.existsSync(manifestFile)) {
+        return
+      }
+
+      const manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf-8'))
+
+      await cleanUpFiles(outDir, manifest, shouldCleanUpSourceMaps(viteConfig, config))
+    },
+  }
+}
+
+export default cleanup

--- a/packages/vite-plugin-cleanup/tsconfig.json
+++ b/packages/vite-plugin-cleanup/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "tsconfig/base.json",
+  "include": [
+    "."
+  ],
+  "compilerOptions": {
+    "lib": ["esnext", "dom"]
+  },
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules"
+  ]
+}

--- a/packages/vite-plugin-page-reload/CHANGELOG.md
+++ b/packages/vite-plugin-page-reload/CHANGELOG.md
@@ -1,5 +1,11 @@
 # vite-plugin-page-reload
 
+## 0.1.1
+
+### Patch Changes
+
+- Parity bump
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/vite-plugin-page-reload/package.json
+++ b/packages/vite-plugin-page-reload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-page-reload",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "repository": {
     "url": "barrel/shopify-vite",

--- a/packages/vite-plugin-shopify/CHANGELOG.md
+++ b/packages/vite-plugin-shopify/CHANGELOG.md
@@ -1,5 +1,11 @@
 # vite-plugin-shopify
 
+## 2.1.3
+
+### Patch Changes
+
+- Parity bump
+
 ## 2.1.2
 
 ### Patch Changes

--- a/packages/vite-plugin-shopify/package.json
+++ b/packages/vite-plugin-shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-shopify",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Vite plugin providing integration for Shopify themes",
   "repository": {
     "url": "barrel/shopify-vite",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,19 @@ importers:
 
   packages/tsconfig: {}
 
+  packages/vite-plugin-cleanup:
+    dependencies:
+      fast-glob:
+        specifier: ^3.2.11
+        version: 3.2.12
+      vite:
+        specifier: ^4.0.4
+        version: 4.2.1(@types/node@18.15.11)(sass@1.60.0)
+    devDependencies:
+      tsconfig:
+        specifier: workspace:*
+        version: link:../tsconfig
+
   packages/vite-plugin-page-reload:
     dependencies:
       picocolors:


### PR DESCRIPTION
This PR introduces `vite-plugin-cleanup`, a Vite plugin that auto cleans up built asset files as well as sourcemap files on build.

## Inspiration
Derived from the ideas of [vite-plugin-shopify-clean](https://www.npmjs.com/package/@by-association-only/vite-plugin-shopify-clean)

