### PR TITLE
Fix vite-tag.liquid is not generated when build.manifest option is false or string

### DIFF
--- a/packages/vite-plugin-shopify/src/config.ts
+++ b/packages/vite-plugin-shopify/src/config.ts
@@ -42,7 +42,7 @@ export default function shopifyConfig (options: Required<Options>): Plugin {
             input: config.build?.rollupOptions?.input ?? input
           },
           // Output manifest file for backend integration
-          manifest: config.build?.manifest || true
+          manifest: typeof config.build?.manifest === 'string' ? config.build.manifest : true
         },
         resolve: {
           // Provide import alias to source code dir for convenience

--- a/packages/vite-plugin-shopify/src/config.ts
+++ b/packages/vite-plugin-shopify/src/config.ts
@@ -42,7 +42,7 @@ export default function shopifyConfig (options: Required<Options>): Plugin {
             input: config.build?.rollupOptions?.input ?? input
           },
           // Output manifest file for backend integration
-          manifest: config.build?.manifest ?? true
+          manifest: config.build?.manifest || true
         },
         resolve: {
           // Provide import alias to source code dir for convenience

--- a/packages/vite-plugin-shopify/src/html.ts
+++ b/packages/vite-plugin-shopify/src/html.ts
@@ -67,7 +67,11 @@ export default function shopifyHTML (options: Required<Options>): Plugin {
         return
       }
 
-      const manifestFilePath = path.resolve(options.themeRoot, 'assets/.vite/manifest.json')
+      const manifestOption = config.build?.manifest
+      const manifestFilePath = path.resolve(
+        options.themeRoot,
+        `assets/${typeof manifestOption === 'string' ? manifestOption : '.vite/manifest.json'}`
+      )
 
       if (!fs.existsSync(manifestFilePath)) {
         return


### PR DESCRIPTION
This fixes the issue mentioned in #117 