### PR TITLE
Update troubleshooting page

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -34,7 +34,7 @@ You can use [`concurrently`](https://github.com/open-cli-tools/concurrently) or 
 $ npm run dev -- --store johns-apparel --live-reload full-page
 ```
 
-## How to cleanup the `assets/` folder?
+## How to cleanup the `assets/` folder (Vite 4)?
 
 To clean up the `assets/` folder, you can disable the default behavior of Vite emptying the
 `outDir` directory on build. Instead, use the


### PR DESCRIPTION
Added Vite 4 to the "How to cleanup the assets/ folder?" section. At the moment, [vite-plugin-shopify-clean](https://www.npmjs.com/package/@by-association-only/vite-plugin-shopify-clean) does not support Vite 5.