### PR TITLE
Add crossorigin="anonymous" to development css links

### DIFF
--- a/packages/vite-plugin-shopify/src/html.ts
+++ b/packages/vite-plugin-shopify/src/html.ts
@@ -209,7 +209,7 @@ const viteTagSnippetDev = (assetHost: string, entrypointsDir: string, reactPlugi
 <script src="${assetHost}/@id/__x00__vite-plugin-shopify:react-refresh" type="module"></script>`}
 <script src="${assetHost}/@vite/client" type="module"></script>
 {% if is_css == true %}
-  {{ file_url | stylesheet_tag }}
+  <link rel="stylesheet" href="{{ file_url }}" crossorigin="anonymous">
 {% else %}
   <script src="{{ file_url }}" type="module"></script>
 {% endif %}

--- a/packages/vite-plugin-shopify/test/__snapshots__/html.test.ts.snap
+++ b/packages/vite-plugin-shopify/test/__snapshots__/html.test.ts.snap
@@ -26,7 +26,7 @@ exports[`vite-plugin-shopify:html > builds out .liquid files for development 1`]
 %}
 <script src=\\"http://localhost:5173/@vite/client\\" type=\\"module\\"></script>
 {% if is_css == true %}
-  {{ file_url | stylesheet_tag }}
+  <link rel=\\"stylesheet\\" href=\\"{{ file_url }}\\" crossorigin=\\"anonymous\\">
 {% else %}
   <script src=\\"{{ file_url }}\\" type=\\"module\\"></script>
 {% endif %}
@@ -60,7 +60,7 @@ exports[`vite-plugin-shopify:html > builds out .liquid files for development wit
 <script src=\\"http://localhost:5173/@id/__x00__vite-plugin-shopify:react-refresh\\" type=\\"module\\"></script>
 <script src=\\"http://localhost:5173/@vite/client\\" type=\\"module\\"></script>
 {% if is_css == true %}
-  {{ file_url | stylesheet_tag }}
+  <link rel=\\"stylesheet\\" href=\\"{{ file_url }}\\" crossorigin=\\"anonymous\\">
 {% else %}
   <script src=\\"{{ file_url }}\\" type=\\"module\\"></script>
 {% endif %}


### PR DESCRIPTION
It's a bit of an edge case, but without crossorigin="anonymous" you can't access the cssRules of stylesheets in dev mode:

![image](https://github.com/barrel/shopify-vite/assets/7397131/74859c11-b8e6-4e57-81f7-b39cfa1b444f)
