### PR TITLE
Check if custom element exists before registering

### DIFF
--- a/examples/preact-shopify/frontend/components/hello-world.jsx
+++ b/examples/preact-shopify/frontend/components/hello-world.jsx
@@ -32,4 +32,4 @@ function HelloWorld () {
   )
 }
 
-register(HelloWorld, 'hello-world')
+customElements.get('hello-world') || register(HelloWorld, 'hello-world');


### PR DESCRIPTION
Hi, 

Firstly, thanks for the excellent and well maintained plugin and the examples that go with it 🙌 

I followed the example for using preact. I found that with `preact-custom-element` I was getting the following error in the console which prevented HMR from working

> Failed to execute 'define' on 'CustomElementRegistry': the name "hello-world" has already been used with this registry

Proposing this minor change the preact example, which first checks if the custom element exists in the registry before trying to register it.