### PR TITLE
Fix allowedHosts placement in vite config file

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -127,11 +127,10 @@ allowing the Theme Editor to bypass the restriction and correctly load your loca
 -  plugins: [shopify(), tailwindcss()],
 +  plugins: [shopify({ tunnel: true }), tailwindcss()],
    server: {
++    allowedHosts: ['.trycloudflare.com'],
      cors: {
        origin: [defaultAllowedOrigins, /\.myshopify\.com$/]
--    }
-+    },
-+    allowedHosts: ['.trycloudflare.com']
+     }
    },
    build: {
      rollupOptions: {


### PR DESCRIPTION
Move allowedHosts to fix local network access in Shopify theme editor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated troubleshooting guide with guidance for Shopify plugin tunnel configuration.
  * Clarified server configuration settings for CORS-related options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->